### PR TITLE
OMEGA-480 | Upstream test_server implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,12 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Go Test
-        run: |
-          go test ./...
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: [1.17.x]
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Test Go
+        run:  go test ./...
           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: [1.17.x]
+          go-version: 1.17.x
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Test Go
         run:  go test ./...
-          

--- a/test_server/README.md
+++ b/test_server/README.md
@@ -1,0 +1,4 @@
+# README
+
+This is the Geode `test_server` library.
+This library implements dummy servers and other utilities for testing Geode code.

--- a/test_server/hello_server.go
+++ b/test_server/hello_server.go
@@ -1,0 +1,18 @@
+package test_server
+
+import "net/http"
+
+// HelloServer is just a type alias for a ServerWrapper
+type HelloServer = ServerWrapper
+
+// MakeHelloServer creates a
+func MakeHelloServer(port int) *HelloServer {
+	s := &http.Server{}
+	s.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("hello world"))
+	})
+	return &ServerWrapper{
+		Server: s,
+		Port:   port,
+	}
+}

--- a/test_server/hello_server_test.go
+++ b/test_server/hello_server_test.go
@@ -1,0 +1,29 @@
+package test_server
+
+import (
+	"io"
+	"net/http"
+	"strconv"
+	"testing"
+)
+
+func TestHelloServer(t *testing.T) {
+	s := MakeHelloServer(4100)
+	s.StartInBackground(t)
+	s.BlockUntilStarted(t)
+	res, err := http.Get("http://localhost:4100/")
+	if err != nil {
+		t.Error(err)
+	}
+	if res.StatusCode != 200 {
+		t.Errorf("Error code was %d, not 200 as expected.", res.StatusCode)
+	}
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Error(err)
+	}
+	if string(b) != "hello world" {
+		t.Errorf("Messages was %s, not 'hello world' as expected.", strconv.Quote(string(b)))
+	}
+	s.Stop(t)
+}

--- a/test_server/test_server.go
+++ b/test_server/test_server.go
@@ -1,0 +1,62 @@
+package test_server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+)
+
+type Server interface {
+	StartInBackground(t *testing.T) error
+	BlockUntilStarted(t *testing.T) error
+	Stop(t *testing.T) error
+}
+
+// ServerWrapper can be used to wrap an http.Server for testing.
+type ServerWrapper struct {
+	// The server must respond with a 200 status code for GET requests to the path "/".
+	Server *http.Server
+	// The port will be used by the server instance.
+	Port int
+}
+
+func (s *ServerWrapper) StartInBackground(t *testing.T) error {
+	s.Server.Addr = "localhost:" + strconv.Itoa(s.Port)
+	go func() {
+		if err := s.Server.ListenAndServe(); err != nil && err.Error() != "http: Server closed" {
+			t.Error(err)
+		}
+	}()
+	return nil
+}
+
+func (s *ServerWrapper) BlockUntilStarted(t *testing.T) error {
+	ok := false
+	for i := 0; i < 10; i += 1 {
+		// heatbeat helloworld server until it starts
+		if resp, err := http.Get("http://localhost:" + strconv.Itoa(s.Port) + "/"); err == nil {
+			if resp.StatusCode == 200 {
+				ok = true
+				break
+			}
+		}
+		time.Sleep(time.Second)
+	}
+	if !ok {
+		err := errors.New("server did not start")
+		t.Error(err)
+		return err
+	}
+	return nil
+}
+
+func (s *ServerWrapper) Stop(t *testing.T) error {
+	if err := s.Server.Shutdown(context.Background()); err != nil {
+		t.Error(err)
+		return err
+	}
+	return nil
+}

--- a/test_server/test_server_test.go
+++ b/test_server/test_server_test.go
@@ -1,0 +1,47 @@
+package test_server
+
+import (
+	"errors"
+	"testing"
+)
+
+type BadTestServer struct{}
+
+func (bts BadTestServer) StartInBackground(t *testing.T) error {
+	err := errors.New("starting in the background failed")
+	t.Error(err)
+	return err
+}
+func (bts BadTestServer) BlockUntilStarted(t *testing.T) error {
+	err := errors.New("server never started")
+	t.Error(err)
+	return err
+
+}
+func (bts BadTestServer) Stop(t *testing.T) error {
+	err := errors.New("server never stopped")
+	t.Error(err)
+	return err
+}
+
+func TestBadTestServer(t *testing.T) {
+	tp := &testing.T{}
+	if tp.Failed() {
+		t.Errorf("new T should not have failed")
+	}
+	bts := BadTestServer{}
+	bts.StartInBackground(tp)
+	if !tp.Failed() {
+		t.Errorf("server should not have started in the background")
+	}
+	tp = &testing.T{}
+	bts.BlockUntilStarted(tp)
+	if !tp.Failed() {
+		t.Errorf("server should never have started")
+	}
+	tp = &testing.T{}
+	bts.Stop(tp)
+	if !tp.Failed() {
+		t.Errorf("server should not have stopped")
+	}
+}


### PR DESCRIPTION
This should be used for booting simple test HTTP servers without re-implementing a "Hello, World!" HTTP server each time an end-to-end check is needed.